### PR TITLE
Fix for Compilation Error with Newer GCC Version

### DIFF
--- a/include/llvm/IR/ValueMap.h
+++ b/include/llvm/IR/ValueMap.h
@@ -99,7 +99,7 @@ public:
   explicit ValueMap(const ExtraData &Data, unsigned NumInitBuckets = 64)
       : Map(NumInitBuckets), Data(Data) {}
 
-  bool hasMD() const { return MDMap; }
+  bool hasMD() const { return static_cast<bool>(MDMap); }
   MDMapT &MD() {
     if (!MDMap)
       MDMap.reset(new MDMapT);


### PR DESCRIPTION
This pull request introduces a small code change that fixes a compilation error encountered when building the project using a newer version of GCC. This error was not present in previous GCC versions, and seems to have emerged due to certain updates in the newer GCC version.

The proposed change has been tested and confirmed to not affect the functionality of the code when compiled using both the newer GCC version and older ones. This ensures backward compatibility and extends support for the newer GCC version, allowing users to leverage improvements and features offered by the latest GCC releases.

It would be helpful to have others test this on their systems as well to confirm the solution's broad applicability.

Please let me know if any additional changes or tests are required. I look forward to your feedback.